### PR TITLE
Refactor/phase 3

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -139,6 +139,8 @@ DEFAULT_AVAILABLE_TAGS = {
     ],
     "dormitory_notice": ["입·퇴사", "시설", "일반", "긴급"],
     "yutopia": ["취업/진로", "비교과/활동", "행사/특강", "학습/교육", "공모전", "장학/혜택"],
+    "computer_notice": ["긴급", "과제/시험", "장학", "취업/진로", "학사", "행사"],
+    "swedu_notice": ["긴급", "과제/시험", "장학", "취업/진로", "학사", "행사"],
 }
 
 DEFAULT_CATEGORY_MAP = {

--- a/core/constants.py
+++ b/core/constants.py
@@ -40,6 +40,8 @@ SITE_NAME_MAP = {
     "eoullim_external": "이음림대외활동",
     "eoullim_study": "이음림스터디",
     "yutopia": "유토피아",
+    "computer_notice": "컴퓨터학부공지",
+    "swedu_notice": "SW중심대학",
 }
 
 # Category Emoji Mappings

--- a/database/migrations/003_preserve_message_ids_on_upsert.sql
+++ b/database/migrations/003_preserve_message_ids_on_upsert.sql
@@ -1,0 +1,115 @@
+-- Migration: Preserve message_ids and discord_thread_id on upsert.
+--
+-- Bug: when a modified notice is re-processed, the upsert RPC overwrote
+-- the previously-stored Telegram message_ids and Discord thread_id with
+-- the freshly-built (empty) values from the new notice payload, breaking
+-- "edit existing message" / "reply to thread" flows.
+--
+-- Fix: on conflict, keep the existing message_ids if the incoming value
+-- is the empty object '{}'::jsonb, and keep the existing discord_thread_id
+-- if the incoming value is NULL.
+
+CREATE OR REPLACE FUNCTION upsert_notice_with_attachments(
+    p_notice JSONB,
+    p_attachments JSONB[]
+)
+RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_notice_id UUID;
+    v_attachment JSONB;
+BEGIN
+    -- 1. Upsert Notice
+    INSERT INTO notices (
+        site_key, article_id, title, url, content, category,
+        published_at, author, content_hash, summary, embedding,
+        image_urls, attachment_text, message_ids, discord_thread_id,
+        deadline, eligibility, start_date, end_date, target_dept, target_grades, tags,
+        updated_at
+    ) VALUES (
+        p_notice->>'site_key',
+        p_notice->>'article_id',
+        p_notice->>'title',
+        p_notice->>'url',
+        p_notice->>'content',
+        p_notice->>'category',
+        (p_notice->>'published_at')::TIMESTAMPTZ,
+        p_notice->>'author',
+        p_notice->>'content_hash',
+        p_notice->>'summary',
+        (p_notice->>'embedding')::VECTOR,
+        CASE
+            WHEN p_notice->'image_urls' IS NULL OR jsonb_typeof(p_notice->'image_urls') = 'null' THEN ARRAY[]::TEXT[]
+            ELSE ARRAY(SELECT jsonb_array_elements_text(p_notice->'image_urls'))
+        END,
+        p_notice->>'attachment_text',
+        COALESCE((p_notice->>'message_ids')::JSONB, '{}'::JSONB),
+        p_notice->>'discord_thread_id',
+        (p_notice->>'deadline')::DATE,
+        CASE
+            WHEN p_notice->'eligibility' IS NULL OR jsonb_typeof(p_notice->'eligibility') = 'null' THEN ARRAY[]::TEXT[]
+            ELSE ARRAY(SELECT jsonb_array_elements_text(p_notice->'eligibility'))
+        END,
+        (p_notice->>'start_date')::DATE,
+        (p_notice->>'end_date')::DATE,
+        p_notice->>'target_dept',
+        CASE
+            WHEN p_notice->'target_grades' IS NULL OR jsonb_typeof(p_notice->'target_grades') = 'null' THEN ARRAY[]::INTEGER[]
+            ELSE ARRAY(SELECT jsonb_array_elements_text(p_notice->'target_grades')::INTEGER)
+        END,
+        CASE
+            WHEN p_notice->'tags' IS NULL OR jsonb_typeof(p_notice->'tags') = 'null' THEN ARRAY[]::TEXT[]
+            ELSE ARRAY(SELECT jsonb_array_elements_text(p_notice->'tags'))
+        END,
+        NOW()
+    )
+    ON CONFLICT (site_key, article_id) DO UPDATE SET
+        title = EXCLUDED.title,
+        url = EXCLUDED.url,
+        content = EXCLUDED.content,
+        category = EXCLUDED.category,
+        published_at = EXCLUDED.published_at,
+        author = EXCLUDED.author,
+        content_hash = EXCLUDED.content_hash,
+        summary = EXCLUDED.summary,
+        embedding = EXCLUDED.embedding,
+        image_urls = EXCLUDED.image_urls,
+        attachment_text = EXCLUDED.attachment_text,
+        message_ids = CASE
+            WHEN EXCLUDED.message_ids = '{}'::jsonb THEN notices.message_ids
+            ELSE EXCLUDED.message_ids
+        END,
+        discord_thread_id = COALESCE(EXCLUDED.discord_thread_id, notices.discord_thread_id),
+        deadline = EXCLUDED.deadline,
+        eligibility = EXCLUDED.eligibility,
+        start_date = EXCLUDED.start_date,
+        end_date = EXCLUDED.end_date,
+        target_dept = EXCLUDED.target_dept,
+        target_grades = EXCLUDED.target_grades,
+        tags = EXCLUDED.tags,
+        updated_at = NOW()
+    RETURNING id INTO v_notice_id;
+
+    -- 2. Delete existing attachments
+    DELETE FROM attachments WHERE notice_id = v_notice_id;
+
+    -- 3. Insert new attachments
+    IF array_length(p_attachments, 1) > 0 THEN
+        FOREACH v_attachment IN ARRAY p_attachments
+        LOOP
+            INSERT INTO attachments (
+                notice_id, name, url, file_size, etag
+            ) VALUES (
+                v_notice_id,
+                v_attachment->>'name',
+                v_attachment->>'url',
+                (v_attachment->>'file_size')::BIGINT,
+                v_attachment->>'etag'
+            );
+        END LOOP;
+    END IF;
+
+    RETURN v_notice_id;
+END;
+$$;

--- a/models/ai_result.py
+++ b/models/ai_result.py
@@ -1,0 +1,79 @@
+"""
+Pydantic schema for the JSON object returned by Gemini analyze_notice prompts.
+
+The AI is instructed via resources/prompts/system_prompt.txt to return
+specific keys, but in practice the model occasionally:
+- emits "미정"/"없음"/"" for date fields where null is expected
+- omits optional fields entirely
+- returns target_grades as strings instead of ints
+
+AIAnalysisResult applies normalizing validators so callers downstream
+always see well-typed values without scattering defensive checks.
+"""
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+_NULL_SENTINELS = {"미정", "없음", "없다", "null", "none", "n/a", "-", ""}
+
+
+def _normalize_optional_str(value):
+    """Treat AI sentinels for 'unknown' as None."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if value.strip().lower() in _NULL_SENTINELS:
+            return None
+        return value.strip()
+    return value
+
+
+class AIAnalysisResult(BaseModel):
+    """Validated result of AIService.analyze_notice."""
+
+    summary: str = ""
+    category: str = "일반"
+    tags: List[str] = Field(default_factory=list)
+    target_grades: List[int] = Field(default_factory=list)
+    target_dept: Optional[str] = None
+    deadline: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    eligibility: List[str] = Field(default_factory=list)
+
+    model_config = {"extra": "ignore"}
+
+    @field_validator("summary", "category", mode="before")
+    @classmethod
+    def _coerce_str(cls, value):
+        if value is None:
+            return ""
+        return str(value)
+
+    @field_validator("tags", "eligibility", mode="before")
+    @classmethod
+    def _coerce_str_list(cls, value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value] if value.strip() else []
+        return [str(v) for v in value if v is not None and str(v).strip()]
+
+    @field_validator("target_grades", mode="before")
+    @classmethod
+    def _coerce_int_list(cls, value):
+        if value is None:
+            return []
+        result = []
+        for v in value:
+            try:
+                result.append(int(v))
+            except (TypeError, ValueError):
+                continue
+        return result
+
+    @field_validator("target_dept", "deadline", "start_date", "end_date", mode="before")
+    @classmethod
+    def _normalize_optional(cls, value):
+        return _normalize_optional_str(value)

--- a/models/target.py
+++ b/models/target.py
@@ -8,3 +8,4 @@ class Target(BaseModel):
     title_selector: str = Field(..., description="CSS selector for the title within a list item")
     link_selector: str = Field(..., description="CSS selector for the link within a list item")
     content_selector: str = Field(..., description="CSS selector for the content area in detail page")
+    enabled: bool = Field(True, description="Whether this target is active in scrape runs")

--- a/resources/targets.json
+++ b/resources/targets.json
@@ -61,7 +61,7 @@
   },
   {
     "key": "eoullim_external",
-    "url": "https://join.yu.ac.kr/front_new/index.php?g_page=program&m_page=program04",
+    "url": "https://join.yu.ac.kr/front_new/index.php?g_page=program&m_page=program03",
     "base_url": "https://join.yu.ac.kr/front_new/",
     "list_selector": "table.responsive tbody tr",
     "title_selector": "td.subject a",
@@ -71,7 +71,7 @@
   },
   {
     "key": "eoullim_study",
-    "url": "https://join.yu.ac.kr/front_new/index.php?g_page=program&m_page=program06",
+    "url": "https://join.yu.ac.kr/front_new/index.php?g_page=program&m_page=program01_02",
     "base_url": "https://join.yu.ac.kr/front_new/",
     "list_selector": "table.responsive tbody tr",
     "title_selector": "td.subject a",

--- a/resources/targets.json
+++ b/resources/targets.json
@@ -88,5 +88,25 @@
     "link_selector": "a",
     "content_selector": "div.description div[data-role='wysiwyg-content']",
     "enabled": true
+  },
+  {
+    "key": "computer_notice",
+    "url": "https://computer.yu.ac.kr/computer/notice/notice.do",
+    "base_url": "https://computer.yu.ac.kr/computer/notice/notice.do",
+    "list_selector": "table tbody tr",
+    "title_selector": "a",
+    "link_selector": "a",
+    "content_selector": ".b-view-content",
+    "enabled": true
+  },
+  {
+    "key": "swedu_notice",
+    "url": "https://swedu.yu.ac.kr/swedu/notice/notice.do",
+    "base_url": "https://swedu.yu.ac.kr/swedu/notice/notice.do",
+    "list_selector": "table tbody tr",
+    "title_selector": "a",
+    "link_selector": "a",
+    "content_selector": ".b-view-content",
+    "enabled": true
   }
 ]

--- a/resources/targets.json
+++ b/resources/targets.json
@@ -6,7 +6,8 @@
     "list_selector": "table tbody tr",
     "title_selector": "a",
     "link_selector": "a",
-    "content_selector": ".b-view-content"
+    "content_selector": ".b-view-content",
+    "enabled": true
   },
   {
     "key": "cse_notice",
@@ -15,7 +16,8 @@
     "list_selector": "table tbody tr",
     "title_selector": "a",
     "link_selector": "a",
-    "content_selector": ".b-view-content"
+    "content_selector": ".b-view-content",
+    "enabled": true
   },
   {
     "key": "bachelor_guide",
@@ -24,7 +26,8 @@
     "list_selector": "table tbody tr",
     "title_selector": "a",
     "link_selector": "a",
-    "content_selector": ".b-view-content"
+    "content_selector": ".b-view-content",
+    "enabled": true
   },
   {
     "key": "dormitory_notice",
@@ -33,7 +36,8 @@
     "list_selector": "table tbody tr",
     "title_selector": "a",
     "link_selector": "a",
-    "content_selector": ".b-view-content"
+    "content_selector": ".b-view-content",
+    "enabled": true
   },
   {
     "key": "dormitory_menu",
@@ -42,7 +46,8 @@
     "list_selector": "table tbody tr",
     "title_selector": "a",
     "link_selector": "a",
-    "content_selector": ".b-view-content"
+    "content_selector": ".b-view-content",
+    "enabled": true
   },
   {
     "key": "eoullim_career",
@@ -51,7 +56,8 @@
     "list_selector": "div.program_list div.program_con",
     "title_selector": "p.pro_title",
     "link_selector": "div.con > a",
-    "content_selector": "div.program_view"
+    "content_selector": "div.program_view",
+    "enabled": true
   },
   {
     "key": "eoullim_external",
@@ -60,7 +66,8 @@
     "list_selector": "table.responsive tbody tr",
     "title_selector": "td.subject a",
     "link_selector": "td.subject a",
-    "content_selector": "div.contents"
+    "content_selector": "div.contents",
+    "enabled": true
   },
   {
     "key": "eoullim_study",
@@ -69,7 +76,8 @@
     "list_selector": "table.responsive tbody tr",
     "title_selector": "td.subject a",
     "link_selector": "td.subject a",
-    "content_selector": "div.contents"
+    "content_selector": "div.contents",
+    "enabled": true
   },
   {
     "key": "yutopia",
@@ -78,6 +86,7 @@
     "list_selector": "ul.columns-4 > li",
     "title_selector": "b.title",
     "link_selector": "a",
-    "content_selector": "div.description div[data-role='wysiwyg-content']"
+    "content_selector": "div.description div[data-role='wysiwyg-content']",
+    "enabled": true
   }
 ]

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -8,12 +8,15 @@ import asyncio
 import random
 import re
 from supabase import Client
+from pydantic import ValidationError
 from core.config import settings
 from core.logger import get_logger
 from core.database import Database
 from core import constants
 from datetime import datetime, timedelta
 import pytz
+
+from models.ai_result import AIAnalysisResult
 
 logger = get_logger(__name__)
 
@@ -175,12 +178,14 @@ class AIService:
             logger.error(f"[AI] Failed to load system prompt: {e}")
             return ""
 
-    async def _save_token_usage(self, prompt_tokens: int, completion_tokens: int):
+    async def _save_token_usage(
+        self, prompt_tokens: int, completion_tokens: int, model: str
+    ):
         if not self.db:
             return
         try:
             data = {
-                "model": settings.GEMINI_MODEL,
+                "model": model,
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
@@ -326,11 +331,11 @@ class AIService:
             logger.error(f"[AI] All models failed. Last error: {last_error}")
             return {"summary": "AI 분석 실패 (All Models Failed)", "category": "일반", "tags": []}
 
-        # Token Tracking
+        # Token Tracking — record under the model that actually responded
         try:
             usage = response.usage_metadata
             await self._save_token_usage(
-                usage.prompt_token_count, usage.candidates_token_count
+                usage.prompt_token_count, usage.candidates_token_count, model_name
             )
         except Exception:
             pass
@@ -346,10 +351,24 @@ class AIService:
         logger.debug(f"[AI] Raw Response for {title}: {response_text}")
 
         try:
-            return json.loads(response_text)
+            raw = json.loads(response_text)
         except json.JSONDecodeError:
             logger.error(f"[AI] JSON parsing failed for {title}: {response_text[:100]}...")
             return {"summary": "AI Parsing Failed", "category": "일반", "tags": []}
+
+        try:
+            validated = AIAnalysisResult.model_validate(raw)
+        except ValidationError as e:
+            logger.warning(
+                f"[AI] AIAnalysisResult validation failed for {title}: {e}. "
+                f"Falling back to defaults with raw fields preserved."
+            )
+            validated = AIAnalysisResult(
+                summary=str(raw.get("summary", "")) or "AI 검증 실패",
+                category=str(raw.get("category", "일반")) or "일반",
+            )
+
+        return validated.model_dump()
 
     async def get_diff_summary(self, old_text: str, new_text: str) -> str:
         """
@@ -367,16 +386,17 @@ class AIService:
             f"--- NEW VERSION ---\n{new_text[:2000]}"
         )
 
+        diff_model = "gemini-2.5-flash-lite"
         try:
             response = await self.client.aio.models.generate_content(
-                model="gemini-2.5-flash-lite",
+                model=diff_model,
                 contents=prompt,
             )
 
             try:
                 usage = response.usage_metadata
                 await self._save_token_usage(
-                    usage.prompt_token_count, usage.candidates_token_count
+                    usage.prompt_token_count, usage.candidates_token_count, diff_model
                 )
             except Exception:
                 pass
@@ -417,8 +437,9 @@ class AIService:
             )
 
             # 3. Call Gemini Vision
+            menu_model = "gemini-2.5-flash"
             response = await self.client.aio.models.generate_content(
-                model="gemini-2.5-flash",
+                model=menu_model,
                 contents=[
                     prompt,
                     types.Part.from_bytes(data=image_data, mime_type="image/jpeg"),
@@ -432,7 +453,7 @@ class AIService:
             try:
                 usage = response.usage_metadata
                 await self._save_token_usage(
-                    usage.prompt_token_count, usage.candidates_token_count
+                    usage.prompt_token_count, usage.candidates_token_count, menu_model
                 )
             except Exception:
                 pass

--- a/services/components/target_manager.py
+++ b/services/components/target_manager.py
@@ -66,8 +66,11 @@ class TargetManager:
             for item in data:
                 try:
                     target = Target(**item)
+                    if not target.enabled:
+                        logger.info(f"[TARGET] Skipping disabled target: {target.key}")
+                        continue
                     target_dict = target.model_dump()
-                    
+
                     # Use ParserFactory for OCP-compliant parser creation
                     target_dict["parser"] = self.parser_factory.get_parser(
                         site_key=target.key,
@@ -77,7 +80,7 @@ class TargetManager:
                         content_selector=target.content_selector,
                     )
                     valid_targets.append(target_dict)
-                    
+
                 except Exception as e:
                     logger.error(
                         f"[TARGET_MANAGER] Invalid target configuration: "

--- a/services/notification/discord.py
+++ b/services/notification/discord.py
@@ -5,6 +5,7 @@ Implements NotificationChannel interface for Strategy Pattern.
 import aiohttp
 import json
 import asyncio
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Dict, List, Optional, Any
 
@@ -33,12 +34,42 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
     Implements NotificationChannel interface for Strategy Pattern compatibility.
     """
 
+    MAX_RATE_LIMIT_RETRIES = 2
+
     def __init__(self):
         self.downloader = AttachmentDownloader()
 
     @property
     def channel_name(self) -> str:
         return "discord"
+
+    @asynccontextmanager
+    async def _discord_request(
+        self,
+        session: aiohttp.ClientSession,
+        method: str,
+        url: str,
+        **kwargs,
+    ):
+        """Issue a Discord API request, transparently retrying on HTTP 429.
+
+        Honors the Retry-After response header (seconds) and retries up to
+        MAX_RATE_LIMIT_RETRIES times. On the final attempt the response is
+        yielded regardless of status so callers can handle the failure.
+        """
+        for attempt in range(self.MAX_RATE_LIMIT_RETRIES + 1):
+            is_last = attempt >= self.MAX_RATE_LIMIT_RETRIES
+            async with session.request(method, url, **kwargs) as resp:
+                if resp.status == 429 and not is_last:
+                    retry_after = float(resp.headers.get("Retry-After", "1") or 1)
+                    logger.warning(
+                        f"[NOTIFIER] Discord rate limited (429). "
+                        f"Sleeping {retry_after}s before retry {attempt + 1}/{self.MAX_RATE_LIMIT_RETRIES}."
+                    )
+                    await asyncio.sleep(retry_after)
+                    continue
+                yield resp
+                return
 
     def is_enabled(self) -> bool:
         """Check if Discord is configured and enabled."""
@@ -381,7 +412,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
             )
 
             try:
-                async with session.post(reply_url, headers=headers, **kwargs) as resp:
+                async with self._discord_request(session, "POST", reply_url, headers=headers, **kwargs) as resp:
                     if resp.status in [200, 201]:
                         logger.info("[NOTIFIER] Discord update reply sent.")
 
@@ -492,7 +523,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                 kwargs = {"json": payload}
 
             logger.info(f"[NOTIFIER] Sending Discord request to {thread_url}")
-            async with session.post(thread_url, headers=headers, **kwargs) as resp:
+            async with self._discord_request(session, "POST", thread_url, headers=headers, **kwargs) as resp:
                 logger.info(f"[NOTIFIER] Discord response status: {resp.status}")
                 if resp.status in [200, 201]:
                     logger.info(
@@ -510,7 +541,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                 # Send as simple message with embed
                                 f_payload = {"embeds": [f_embed]}
                                 f_url = f"https://discord.com/api/v10/channels/{created_thread_id}/messages"
-                                async with session.post(f_url, headers=headers, json=f_payload) as f_resp:
+                                async with self._discord_request(session, "POST", f_url, headers=headers, json=f_payload) as f_resp:
                                     if f_resp.status not in [200, 201]:
                                         logger.error(f"[NOTIFIER] Failed to send followup embed {idx+1}: {await f_resp.text()}")
                                 await asyncio.sleep(0.5) # Rate limit safety
@@ -577,7 +608,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
             else:
                 kwargs = {"json": payload}
 
-            async with session.post(message_url, headers=headers, **kwargs) as resp:
+            async with self._discord_request(session, "POST", message_url, headers=headers, **kwargs) as resp:
                 if resp.status in [200, 204]:
                     logger.info(f"[NOTIFIER] Discord Message sent: {notice.title}")
                     resp_data = await resp.json()
@@ -704,7 +735,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
         if reply_to_id:
             payload["message_reference"] = {"message_id": reply_to_id}
             
-        async with session.post(url, headers=headers, json=payload) as resp:
+        async with self._discord_request(session, "POST", url, headers=headers, json=payload) as resp:
             if resp.status not in [200, 201]:
                  logger.error(f"[NOTIFIER] Failed to send reply embed: {await resp.text()}")
 
@@ -740,7 +771,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                 )
 
             try:
-                async with session.post(url, headers=headers, data=form) as resp:
+                async with self._discord_request(session, "POST", url, headers=headers, data=form) as resp:
                     if resp.status not in [200, 201, 204]:
                         logger.error(
                             f"[NOTIFIER] Failed to send reply attachments: {await resp.text()}"
@@ -766,7 +797,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
             for idx, img in enumerate(group["images"]):
                 self._add_file_part(form, f"files[{idx}]", img["data"], img["filename"])
 
-            async with session.post(message_url, headers=headers, data=form) as resp:
+            async with self._discord_request(session, "POST", message_url, headers=headers, data=form) as resp:
                 if resp.status in [200, 201]:
                     logger.info(
                         f"[NOTIFIER] Sent Discord PDF preview group: {caption} ({len(group['images'])} pages)"

--- a/services/polaris_service.py
+++ b/services/polaris_service.py
@@ -12,17 +12,25 @@ logger = get_logger(__name__)
 class PolarisService:
     def __init__(self):
         self.url = "https://www.polarisofficetools.com/hwpx/convert/image"
+        # Circuit breaker: once a conversion fails (timeout, network, etc.) we
+        # stop attempting subsequent files within the same scrape run to avoid
+        # repeatedly burning 120s on a service that is currently down.
+        self._circuit_open = False
 
     def convert_to_jpg(self, file_path: str, output_dir: str) -> List[str]:
         """
         Converts HWP/HWPX file to JPG using Polaris Office Tools via a separate subprocess.
         Returns a list of paths to the downloaded JPG files.
         """
+        if self._circuit_open:
+            logger.warning("[POLARIS] Circuit breaker activated, skipping remaining files")
+            return []
+
         # Create debug directory
         debug_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "debug_screenshots"))
         if not os.path.exists(debug_dir):
             os.makedirs(debug_dir)
-            
+
         try:
             logger.info(f"[POLARIS] Starting conversion for {file_path}")
 
@@ -55,7 +63,7 @@ def run_conversion():
 
             # Phase 1: Navigate and wait for page load
             print(f"[SCRIPT] Navigating to {{url}}...")
-            page.goto(url, wait_until="domcontentloaded")
+            page.goto(url, wait_until="domcontentloaded", timeout=30000)
             page.wait_for_timeout(3000)
 
             # Wait for desktop loading indicator to disappear
@@ -350,6 +358,7 @@ if __name__ == "__main__":
                 
             if result.returncode != 0:
                 logger.error(f"[POLARIS] Worker failed with exit code {result.returncode}")
+                self._circuit_open = True
                 return []
 
             # Parse output for downloaded files (supports multiple OUTPUT_FILE lines from fallback)
@@ -362,6 +371,7 @@ if __name__ == "__main__":
 
             if not downloaded_files:
                 logger.error("[POLARIS] No output file found from worker")
+                self._circuit_open = True
                 return []
 
             # Process downloaded files (ZIP or individual images)
@@ -376,10 +386,11 @@ if __name__ == "__main__":
                                 extracted_files.append(os.path.join(output_dir, name))
                 elif downloaded_file.lower().endswith(('.jpg', '.jpeg', '.png')):
                     extracted_files.append(downloaded_file)
-            
+
             logger.info(f"[POLARIS] Extracted {len(extracted_files)} images")
             return extracted_files
 
         except Exception as e:
             logger.error(f"[POLARIS] Conversion error: {e}")
+            self._circuit_open = True
             return []

--- a/tests/test_scraper_e2e.py
+++ b/tests/test_scraper_e2e.py
@@ -1,0 +1,182 @@
+"""End-to-end mock test for ScraperService.process_target.
+
+Stubs every collaborator (fetcher, parser, analyzer, repo, notifier,
+change_detector, hash_calculator, attachment_processor) so the test can
+verify the orchestration sequence without hitting the network or DB.
+
+Two scenarios:
+- new notice → upsert + Telegram/Discord notify
+- modified notice (hash changed, change_detector confirms) → upsert + notify
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.notice import Notice
+from services.scraper_service import ScraperService
+
+
+def _build_scraper(*, processed_ids, old_notice=None, detect_modifications_result=None):
+    """Construct a ScraperService with all collaborators mocked.
+
+    processed_ids: dict returned by repo.get_last_processed_ids
+    old_notice: Notice instance returned by repo.get_notice (None for new flow)
+    detect_modifications_result: dict returned by change_detector.detect_modifications
+    """
+    fetcher = MagicMock()
+    fetcher.fetch_url = AsyncMock(side_effect=["<list-html/>", "<detail-html/>"])
+    fetcher.create_session = AsyncMock()
+
+    list_notice = Notice(
+        site_key="yu_news",
+        article_id="42",
+        title="Scholarship Announcement",
+        url="https://www.yu.ac.kr/main/intro/yu-news.do?articleNo=42",
+        content="",
+    )
+    detail_notice = Notice(
+        site_key="yu_news",
+        article_id="42",
+        title="Scholarship Announcement",
+        url="https://www.yu.ac.kr/main/intro/yu-news.do?articleNo=42",
+        content="장학금 신청 안내. 신청기간: 2026-05-01 ~ 2026-05-31",
+    )
+
+    parser = MagicMock()
+    parser.parse_list = MagicMock(return_value=[list_notice])
+    parser.parse_detail = MagicMock(return_value=detail_notice)
+
+    analyzer = MagicMock()
+    # ContentAnalyzer.analyze_notice: returns a Notice with AI metadata applied
+    async def _analyze(notice):
+        notice.summary = "AI 요약"
+        notice.category = "장학"
+        notice.tags = ["장학"]
+        notice.embedding = [0.0] * 768
+        return notice
+    analyzer.analyze_notice = AsyncMock(side_effect=_analyze)
+
+    repo = MagicMock()
+    repo.get_last_processed_ids = MagicMock(return_value=processed_ids)
+    repo.get_notice = MagicMock(return_value=old_notice)
+    repo.upsert_notice = MagicMock(return_value="notice-uuid-1")
+    repo.get_notice_id = MagicMock(return_value="notice-uuid-1")
+    repo.update_message_ids = MagicMock()
+    repo.update_discord_thread_id = MagicMock()
+
+    notifier = MagicMock()
+    notifier.send_telegram = AsyncMock(return_value=12345)
+    notifier.send_discord = AsyncMock(return_value="discord-thread-1")
+
+    change_detector = MagicMock()
+    change_detector.should_process_article = AsyncMock(return_value=True)
+    change_detector.detect_modifications = AsyncMock(
+        return_value=detect_modifications_result
+    )
+
+    hash_calculator = MagicMock()
+    hash_calculator.calculate_hash = MagicMock(return_value="new-hash")
+
+    attachment_processor = MagicMock()
+    attachment_processor.process_attachments = AsyncMock()
+
+    target_manager = MagicMock()
+    target_manager.load_targets = MagicMock()
+    target_manager.get_targets = MagicMock(return_value=[])
+
+    scraper = ScraperService(
+        no_ai_mode=False,
+        notifier=notifier,
+        repo=repo,
+        target_manager=target_manager,
+        hash_calculator=hash_calculator,
+        change_detector=change_detector,
+        attachment_processor=attachment_processor,
+        fetcher=fetcher,
+        parser=parser,
+        analyzer=analyzer,
+    )
+    return scraper, {
+        "fetcher": fetcher,
+        "parser": parser,
+        "analyzer": analyzer,
+        "repo": repo,
+        "notifier": notifier,
+        "change_detector": change_detector,
+        "hash_calculator": hash_calculator,
+    }
+
+
+@pytest.mark.asyncio
+async def test_new_notice_full_pipeline():
+    """A first-time-seen article goes through fetch → parse → analyze → upsert → notify."""
+    scraper, mocks = _build_scraper(processed_ids={})
+    session = MagicMock()
+
+    target = {
+        "key": "yu_news",
+        "url": "https://www.yu.ac.kr/main/intro/yu-news.do",
+        "base_url": "https://www.yu.ac.kr",
+        "parser": MagicMock(),
+    }
+
+    await scraper.process_target(session, target)
+
+    # fetch called twice: list page + detail page
+    assert mocks["fetcher"].fetch_url.await_count == 2
+    # parser invoked for both list and detail
+    mocks["parser"].parse_list.assert_called_once()
+    mocks["parser"].parse_detail.assert_called_once()
+    # AI analysis ran (no_ai_mode=False, no skip)
+    mocks["analyzer"].analyze_notice.assert_awaited_once()
+    # upsert and both notifications fired
+    mocks["repo"].upsert_notice.assert_called_once()
+    mocks["notifier"].send_telegram.assert_awaited_once()
+    mocks["notifier"].send_discord.assert_awaited_once()
+    # is_new path: did not call get_notice or change_detector
+    mocks["repo"].get_notice.assert_not_called()
+    mocks["change_detector"].should_process_article.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modified_notice_full_pipeline():
+    """An existing article with a changed hash flows through change detection
+    into a notification with modified_reason populated from the diff."""
+    old_notice = Notice(
+        site_key="yu_news",
+        article_id="42",
+        title="Old Title",
+        url="https://www.yu.ac.kr/main/intro/yu-news.do?articleNo=42",
+        content="이전 내용",
+        content_hash="old-hash",
+    )
+    scraper, mocks = _build_scraper(
+        processed_ids={"42": "old-hash"},
+        old_notice=old_notice,
+        detect_modifications_result={"title": "'Old Title' -> 'Scholarship Announcement'"},
+    )
+    session = MagicMock()
+
+    target = {
+        "key": "yu_news",
+        "url": "https://www.yu.ac.kr/main/intro/yu-news.do",
+        "base_url": "https://www.yu.ac.kr",
+        "parser": MagicMock(),
+    }
+
+    await scraper.process_target(session, target)
+
+    # Existing-record path: change_detector consulted twice
+    mocks["change_detector"].should_process_article.assert_awaited_once()
+    mocks["change_detector"].detect_modifications.assert_awaited_once()
+    # Hash differs ("new-hash" vs "old-hash") so we proceed to AI + upsert
+    mocks["analyzer"].analyze_notice.assert_awaited_once()
+    mocks["repo"].upsert_notice.assert_called_once()
+    # Notifications still go out
+    mocks["notifier"].send_telegram.assert_awaited_once()
+    mocks["notifier"].send_discord.assert_awaited_once()
+    # The is_new flag passed to send_telegram should be False
+    _, send_kwargs = mocks["notifier"].send_telegram.call_args
+    assert send_kwargs.get("changes") == {
+        "title": "'Old Title' -> 'Scholarship Announcement'"
+    }

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -1,0 +1,162 @@
+"""Tests for AuthService SSO login flow.
+
+The real implementation drives Playwright against portal.yu.ac.kr; here we
+mock the Playwright async context-manager stack and exercise the four
+outcomes that matter:
+
+- successful redirect to the protected domain with cookies
+- redirect failure (still on SSO domain) → returns None
+- redirect succeeded but no cookies for target domain → returns None
+- page.goto raises (timeout / network) → returns None
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.config import settings
+from services.auth_service import AuthService
+
+
+def _build_playwright_stack(*, page_url: str, cookies):
+    """Construct a fully-mocked Playwright stack with given page.url and cookies.
+
+    Returns (async_playwright_factory, page) — pass the factory to
+    monkeypatch.setattr and assert on `page` if needed.
+    """
+    page = MagicMock()
+    page.url = page_url
+    page.goto = AsyncMock()
+    page.wait_for_selector = AsyncMock()
+    page.reload = AsyncMock()
+    # query_selector returns a truthy stand-in for the form element
+    page.query_selector = AsyncMock(return_value=MagicMock())
+    page.fill = AsyncMock()
+    page.press = AsyncMock()
+    page.wait_for_url = AsyncMock()
+    page.wait_for_load_state = AsyncMock()
+    page.screenshot = AsyncMock()
+
+    context = MagicMock()
+    context.new_page = AsyncMock(return_value=page)
+    # context.cookies is called twice: once with target URL filter, once for all
+    context.cookies = AsyncMock(side_effect=lambda *args, **kwargs: cookies)
+
+    browser = MagicMock()
+    browser.new_context = AsyncMock(return_value=context)
+    browser.close = AsyncMock()
+
+    chromium = MagicMock()
+    chromium.launch = AsyncMock(return_value=browser)
+
+    p = MagicMock()
+    p.chromium = chromium
+
+    pw_cm = MagicMock()
+    pw_cm.__aenter__ = AsyncMock(return_value=p)
+    pw_cm.__aexit__ = AsyncMock(return_value=None)
+
+    return (lambda: pw_cm), page
+
+
+@pytest.fixture
+def credentials_set(monkeypatch):
+    """Provide non-empty YU_EOULLIM_ID/PW so AuthService doesn't bail early."""
+    monkeypatch.setattr(settings, "YU_EOULLIM_ID", "test_user")
+    monkeypatch.setattr(settings, "YU_EOULLIM_PW", "test_pw")
+
+
+@pytest.mark.asyncio
+async def test_eoullim_login_success(monkeypatch, credentials_set):
+    """Redirect lands on join.yu.ac.kr and cookies are returned."""
+    factory, _ = _build_playwright_stack(
+        page_url="https://join.yu.ac.kr/main/index.do",
+        cookies=[
+            {"name": "JSESSIONID", "value": "abc123", "domain": "join.yu.ac.kr"},
+            {"name": "SAML2", "value": "xyz", "domain": "join.yu.ac.kr"},
+        ],
+    )
+    monkeypatch.setattr("services.auth_service.async_playwright", factory)
+
+    svc = AuthService()
+    cookies = await svc.get_eoullim_cookies()
+
+    assert cookies == {"JSESSIONID": "abc123", "SAML2": "xyz"}
+
+
+@pytest.mark.asyncio
+async def test_eoullim_login_redirect_failure(monkeypatch, credentials_set):
+    """Login form was submitted but URL is still on SSO domain → None."""
+    factory, _ = _build_playwright_stack(
+        page_url="https://portal.yu.ac.kr/sso/login.jsp?error=1",
+        cookies=[],
+    )
+    monkeypatch.setattr("services.auth_service.async_playwright", factory)
+
+    svc = AuthService()
+    cookies = await svc.get_eoullim_cookies()
+
+    assert cookies is None
+
+
+@pytest.mark.asyncio
+async def test_eoullim_login_no_cookies(monkeypatch, credentials_set):
+    """Reached target domain but no cookies registered → None."""
+    factory, _ = _build_playwright_stack(
+        page_url="https://join.yu.ac.kr/main",
+        cookies=[],
+    )
+    monkeypatch.setattr("services.auth_service.async_playwright", factory)
+
+    svc = AuthService()
+    cookies = await svc.get_eoullim_cookies()
+
+    assert cookies is None
+
+
+@pytest.mark.asyncio
+async def test_eoullim_login_goto_timeout(monkeypatch, credentials_set):
+    """page.goto raises (timeout / network) → method returns None, no crash."""
+    factory, page = _build_playwright_stack(
+        page_url="about:blank",
+        cookies=[],
+    )
+    page.goto = AsyncMock(side_effect=TimeoutError("Navigation timeout"))
+    monkeypatch.setattr("services.auth_service.async_playwright", factory)
+
+    svc = AuthService()
+    cookies = await svc.get_eoullim_cookies()
+
+    assert cookies is None
+
+
+@pytest.mark.asyncio
+async def test_eoullim_login_skipped_without_credentials(monkeypatch):
+    """Empty credentials short-circuit before touching Playwright."""
+    monkeypatch.setattr(settings, "YU_EOULLIM_ID", None)
+    monkeypatch.setattr(settings, "YU_EOULLIM_PW", None)
+
+    # If Playwright is touched, this would AttributeError — assert it isn't.
+    monkeypatch.setattr(
+        "services.auth_service.async_playwright",
+        lambda: (_ for _ in ()).throw(AssertionError("playwright should not be called")),
+    )
+
+    svc = AuthService()
+    cookies = await svc.get_eoullim_cookies()
+
+    assert cookies is None
+
+
+@pytest.mark.asyncio
+async def test_yutopia_login_redirect_failure(monkeypatch, credentials_set):
+    """Sibling test for the YUtopia branch — same domain-check failure path."""
+    factory, _ = _build_playwright_stack(
+        page_url="https://portal.yu.ac.kr/sso/login.jsp?error=2",
+        cookies=[],
+    )
+    monkeypatch.setattr("services.auth_service.async_playwright", factory)
+
+    svc = AuthService()
+    cookies = await svc.get_yutopia_cookies()
+
+    assert cookies is None


### PR DESCRIPTION
## Phase 3: 안정성 + 테스트 + 기능 추가

### 안정성 수정
- upsert 시 message_ids/discord_thread_id 기존값 보존
- Discord 429 rate limit 재시도 (Retry-After 기반)
- Polaris circuit breaker + 타임아웃 120s → 30s
- AI 응답 Pydantic 검증 + 토큰 사용량 실제 모델명 기록

### 테스트 확충
- SSO Auth 테스트 6 시나리오
- Scraper E2E Mock 테스트 (새 공지 + 수정 공지)

### 기능 추가
- 타겟 enabled/disabled 토글
- 어울림 URL 업데이트 (program04→03, program06→01_02)
- 컴퓨터학부 공지 타겟 추가
- SW중심대학 타겟 추가 (disabled)