### PR TITLE
fix(notify): improve diff readability and notification formatting

### DIFF
--- a/services/file/__init__.py
+++ b/services/file/__init__.py
@@ -3,10 +3,28 @@ File service initialization.
 Exports all file-related classes for easy importing.
 """
 
-from services.file.base import BaseFileHandler
-from services.file.pdf import PDFHandler
-from services.file.hwp import HWPHandler
-from services.file.office import OfficeHandler
-from services.file.image import ImageHandler
-
 __all__ = ["BaseFileHandler", "PDFHandler", "HWPHandler", "OfficeHandler", "ImageHandler"]
+
+
+def __getattr__(name):
+    if name == "BaseFileHandler":
+        from services.file.base import BaseFileHandler
+
+        return BaseFileHandler
+    if name == "PDFHandler":
+        from services.file.pdf import PDFHandler
+
+        return PDFHandler
+    if name == "HWPHandler":
+        from services.file.hwp import HWPHandler
+
+        return HWPHandler
+    if name == "OfficeHandler":
+        from services.file.office import OfficeHandler
+
+        return OfficeHandler
+    if name == "ImageHandler":
+        from services.file.image import ImageHandler
+
+        return ImageHandler
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/services/file/image.py
+++ b/services/file/image.py
@@ -4,8 +4,6 @@ Image processing utilities.
 import io
 from typing import List
 
-import fitz  # PyMuPDF
-
 from core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -17,6 +15,8 @@ class ImageHandler:
     def images_to_pdf(self, image_paths: List[str]) -> bytes:
         """Converts a list of images to a single PDF."""
         try:
+            import fitz  # PyMuPDF
+
             doc = fitz.open()
 
             for img_path in image_paths:

--- a/services/file/pdf.py
+++ b/services/file/pdf.py
@@ -6,7 +6,6 @@ import tempfile
 import os
 from typing import Optional, List
 
-import fitz  # PyMuPDF
 from pypdf import PdfReader
 
 from core.logger import get_logger
@@ -40,6 +39,8 @@ class PDFHandler:
         """
         images = []
         try:
+            import fitz  # PyMuPDF
+
             doc = fitz.open(stream=file_data, filetype="pdf")
             page_count = min(len(doc), max_pages)
 

--- a/services/file_service.py
+++ b/services/file_service.py
@@ -9,18 +9,19 @@ import os
 import subprocess
 import tempfile
 import zipfile
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 
-import fitz  # PyMuPDF
 from PIL import Image
 
 from core.logger import get_logger
 from services.polaris_service import PolarisService
 from services.file.base import BaseFileHandler
-from services.file.pdf import PDFHandler
 from services.file.hwp import HWPHandler
 from services.file.office import OfficeHandler
-from services.file.image import ImageHandler
+
+if TYPE_CHECKING:
+    from services.file.pdf import PDFHandler
+    from services.file.image import ImageHandler
 
 logger = get_logger(__name__)
 
@@ -36,17 +37,33 @@ class FileService(BaseFileHandler):
         self,
         # Dependency Injection - Optional, defaults to real implementations
         polaris_service: Optional[PolarisService] = None,
-        pdf_handler: Optional[PDFHandler] = None,
+        pdf_handler: Optional["PDFHandler"] = None,
         hwp_handler: Optional[HWPHandler] = None,
         office_handler: Optional[OfficeHandler] = None,
-        image_handler: Optional[ImageHandler] = None,
+        image_handler: Optional["ImageHandler"] = None,
     ):
         # Inject or create default instances
         self.polaris_service = polaris_service or PolarisService()
-        self.pdf_handler = pdf_handler or PDFHandler()
+        self._pdf_handler = pdf_handler
         self.hwp_handler = hwp_handler or HWPHandler()
         self.office_handler = office_handler or OfficeHandler()
-        self.image_handler = image_handler or ImageHandler()
+        self._image_handler = image_handler
+
+    @property
+    def pdf_handler(self) -> "PDFHandler":
+        if self._pdf_handler is None:
+            from services.file.pdf import PDFHandler
+
+            self._pdf_handler = PDFHandler()
+        return self._pdf_handler
+
+    @property
+    def image_handler(self) -> "ImageHandler":
+        if self._image_handler is None:
+            from services.file.image import ImageHandler
+
+            self._image_handler = ImageHandler()
+        return self._image_handler
 
     def extract_text(self, file_data: bytes, filename: str) -> str:
         """Extracts text from PDF or HWP files."""
@@ -308,6 +325,8 @@ class FileService(BaseFileHandler):
                 pdf_data = self.convert_to_pdf(file_data, filename)
                 if not pdf_data:
                     return []
+
+            import fitz  # PyMuPDF
 
             doc = fitz.open(stream=pdf_data, filetype="pdf")
             preview_images = []

--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -3,9 +3,24 @@ Notification service initialization.
 Exports all notification-related classes for easy importing.
 """
 
-from services.notification.base import BaseNotifier
-from services.notification.telegram import TelegramNotifier
-from services.notification.discord import DiscordNotifier
-from services.notification import formatters
+import importlib
 
 __all__ = ["BaseNotifier", "TelegramNotifier", "DiscordNotifier", "formatters"]
+
+
+def __getattr__(name):
+    if name == "BaseNotifier":
+        from services.notification.base import BaseNotifier
+
+        return BaseNotifier
+    if name == "TelegramNotifier":
+        from services.notification.telegram import TelegramNotifier
+
+        return TelegramNotifier
+    if name == "DiscordNotifier":
+        from services.notification.discord import DiscordNotifier
+
+        return DiscordNotifier
+    if name == "formatters":
+        return importlib.import_module("services.notification.formatters")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/services/notification/discord.py
+++ b/services/notification/discord.py
@@ -19,7 +19,11 @@ from models.notice import Notice
 from services.file.attachment_downloader import AttachmentDownloader
 from services.notification.base import BaseNotifier, NotificationChannel
 from services.notification.diff_chunker import split_diff
-from services.notification.formatters import create_discord_embed, format_change_summary
+from services.notification.formatters import (
+    create_discord_embed,
+    create_revised_body_quote_field,
+    format_change_summary,
+)
 from services.tag_matcher import TagMatcher
 
 # Discord embed field max is 1024; inline bold diff is sent as plain field text.
@@ -488,6 +492,9 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                 "inline": False,
                             }
                         )
+                    revised_field = create_revised_body_quote_field(new_content)
+                    if revised_field:
+                        embed["fields"].append(revised_field)
 
         # Add attachment links as the last field (before footer)
         if notice.attachments:
@@ -633,6 +640,9 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                     "inline": False,
                                 }
                             )
+                    revised_field = create_revised_body_quote_field(new_content)
+                    if revised_field:
+                        update_embed["fields"].append(revised_field)
 
             # Prepare Payload
             payload = {"embeds": [update_embed]}

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -446,12 +446,20 @@ def strip_html_text(
     return text
 
 
-def get_notice_quote_text(notice, max_length: int) -> str:
+def get_notice_quote_text(
+    notice, max_length: int, bullet_summary: bool = False
+) -> str:
     """Prefer AI summary, then stripped notice body, for compact quote previews."""
-    source = notice.summary or notice.content or ""
-    if source.startswith("[단신]"):
+    summary = notice.summary or ""
+    is_ai_summary = bool(summary and not summary.startswith("[단신]"))
+    source = summary or notice.content or ""
+    if summary.startswith("[단신]"):
         source = source.replace("[단신]", "", 1).strip()
-    return strip_html_text(source, max_length=max_length)
+
+    text = strip_html_text(source)
+    if is_ai_summary and bullet_summary:
+        text = format_summary_lines(text)
+    return truncate_text(text, max_length)
 
 
 def format_date(dt_str: str) -> str:
@@ -541,7 +549,9 @@ def create_discord_embed(notice, is_new: bool, modified_reason: str = "", change
     # However, if we don't have detailed changes but have a reason, we can mention it here or in fields.
     # Logic moved to Field generation.
 
-    quote_text = get_notice_quote_text(notice, DISCORD_QUOTE_LENGTH)
+    quote_text = get_notice_quote_text(
+        notice, DISCORD_QUOTE_LENGTH, bullet_summary=True
+    )
     if quote_text:
         description_text += f"{summary_header}\n{quote_text}"
 
@@ -644,7 +654,9 @@ def create_telegram_message(notice, is_new: bool, modified_reason: str = "", cha
     elif not is_new and modified_reason:
         msg += f"⚠️ <b>수정 사항</b>: {modified_reason}\n\n"
 
-    quote_text = get_notice_quote_text(notice, TELEGRAM_QUOTE_LENGTH)
+    quote_text = get_notice_quote_text(
+        notice, TELEGRAM_QUOTE_LENGTH, bullet_summary=True
+    )
     if quote_text:
         msg += f"{summary_header}\n<blockquote>{escape_html(quote_text)}</blockquote>\n\n"
 

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -6,6 +6,7 @@ Provides diff generation, emoji mappings, text formatting, and message creation.
 import difflib
 import html
 import re
+import textwrap
 from datetime import datetime
 from typing import Dict, Any, Optional
 
@@ -30,6 +31,8 @@ CONTEXT_DIFF_CHARS = 30
 CONTEXT_DIFF_GROUP_EQUAL_LIMIT = 6
 TELEGRAM_QUOTE_LENGTH = 500
 DISCORD_QUOTE_LENGTH = 1000
+REVISED_BODY_QUOTE_LENGTH = 500
+REVISED_BODY_WRAP_WIDTH = 100
 
 
 def generate_clean_diff(
@@ -434,8 +437,12 @@ def strip_html_text(
     soup = BeautifulSoup(raw_text, "html.parser")
     for tag in soup(["script", "style", "img"]):
         tag.decompose()
+    for tag in soup.find_all("br"):
+        tag.replace_with("\n")
+    for tag in soup.find_all(["p", "div", "li", "tr"]):
+        tag.append("\n")
 
-    text = soup.get_text("\n")
+    text = soup.get_text(" ")
     text = html.unescape(text)
     text = re.sub(r"[ \t]+", " ", text)
     text = re.sub(r" *\n *", "\n", text)
@@ -460,6 +467,50 @@ def get_notice_quote_text(
     if is_ai_summary and bullet_summary:
         text = format_summary_lines(text)
     return truncate_text(text, max_length)
+
+
+def format_revised_body_quote(
+    raw_text: str, max_length: int = REVISED_BODY_QUOTE_LENGTH
+) -> str:
+    """Format the revised body for compact modified-notice detail replies."""
+    text = strip_html_text(raw_text)
+    if not text:
+        return ""
+    text = _break_long_text_by_sentence(text)
+    return truncate_text(text, max_length)
+
+
+def format_telegram_revised_body_quote(raw_text: str) -> str:
+    quote = format_revised_body_quote(raw_text)
+    if not quote:
+        return ""
+    escaped = html.escape(quote, quote=False)
+    return f"📝 <b>수정 후 원문</b>\n<blockquote>{escaped}</blockquote>"
+
+
+def create_revised_body_quote_field(raw_text: str) -> Optional[Dict[str, Any]]:
+    quote = format_revised_body_quote(raw_text)
+    if not quote:
+        return None
+    return {"name": "📝 수정 후 원문", "value": quote, "inline": False}
+
+
+def _break_long_text_by_sentence(text: str) -> str:
+    if "\n" in text or len(text) <= REVISED_BODY_WRAP_WIDTH:
+        return text
+
+    sentences = [part.strip() for part in re.split(r"(?<=\.)\s*", text) if part.strip()]
+    if len(sentences) > 1:
+        return "\n".join(sentences)
+
+    return "\n".join(
+        textwrap.wrap(
+            text,
+            width=REVISED_BODY_WRAP_WIDTH,
+            break_long_words=True,
+            replace_whitespace=False,
+        )
+    )
 
 
 def format_date(dt_str: str) -> str:

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -26,6 +26,8 @@ SCHOOL_LOGO_URL = constants.SCHOOL_LOGO_URL
 INLINE_DIFF_MIN_LINE_LENGTH = 30
 INLINE_DIFF_MIN_RATIO = 0.45
 INLINE_DIFF_MIN_SPAN = 2
+CONTEXT_DIFF_CHARS = 30
+CONTEXT_DIFF_GROUP_EQUAL_LIMIT = 6
 TELEGRAM_QUOTE_LENGTH = 500
 DISCORD_QUOTE_LENGTH = 1000
 
@@ -63,11 +65,16 @@ def generate_clean_diff(
         if tag == "replace":
             paired = min(len(old_lines), len(new_lines))
             for idx in range(paired):
-                old_line, new_line = _highlight_line_pair(
-                    old_lines[idx].strip(), new_lines[idx].strip(), inline_style
+                old_line = old_lines[idx].strip()
+                new_line = new_lines[idx].strip()
+                context_lines = _context_diff_lines(
+                    old_line, new_line, inline_style
                 )
-                changes.append(f"🔴 {old_line}")
-                changes.append(f"🟢 {new_line}")
+                if context_lines:
+                    changes.extend(context_lines)
+                else:
+                    changes.append(f"🔴 {_format_diff_line(old_line, inline_style)}")
+                    changes.append(f"🟢 {_format_diff_line(new_line, inline_style)}")
 
             for line in old_lines[paired:]:
                 changes.append(f"🔴 {_format_diff_line(line.strip(), inline_style)}")
@@ -82,6 +89,135 @@ def generate_clean_diff(
 
     # Return full result without truncation
     return "\n".join(changes)
+
+
+def _context_diff_lines(
+    old_line: str, new_line: str, inline_style: Optional[str]
+) -> Optional[list[str]]:
+    if (
+        len(old_line) < INLINE_DIFF_MIN_LINE_LENGTH
+        or len(new_line) < INLINE_DIFF_MIN_LINE_LENGTH
+    ):
+        return None
+
+    matcher = difflib.SequenceMatcher(None, old_line, new_line)
+    if matcher.ratio() < INLINE_DIFF_MIN_RATIO:
+        return None
+
+    groups = _context_token_change_groups(old_line, new_line)
+    if not groups:
+        groups = _context_change_groups(matcher.get_opcodes())
+    if not groups:
+        return None
+
+    lines = []
+    for old_start, old_end, new_start, new_end in groups:
+        old_start, old_end = _trim_range(old_line, old_start, old_end)
+        new_start, new_end = _trim_range(new_line, new_start, new_end)
+
+        old_segment = old_line[old_start:old_end]
+        new_segment = new_line[new_start:new_end]
+        if not (
+            _has_meaningful_span(old_segment) or _has_meaningful_span(new_segment)
+        ):
+            continue
+
+        context_line = new_line if new_start < new_end else old_line
+        context_start = new_start if new_start < new_end else old_start
+        context_end = new_end if new_start < new_end else old_end
+        before_start = max(0, context_start - CONTEXT_DIFF_CHARS)
+        after_end = min(len(context_line), context_end + CONTEXT_DIFF_CHARS)
+
+        before = context_line[before_start:context_start]
+        after = context_line[context_end:after_end]
+        prefix = "..." if before_start > 0 else ""
+        suffix = "..." if after_end < len(context_line) else ""
+        lines.append(
+            "".join(
+                [
+                    prefix,
+                    _format_diff_line(before, inline_style),
+                    "[",
+                    _format_diff_line(old_segment, inline_style),
+                    " → ",
+                    _format_diff_line(new_segment, inline_style),
+                    "]",
+                    _format_diff_line(after, inline_style),
+                    suffix,
+                ]
+            )
+        )
+
+    return lines or None
+
+
+def _context_token_change_groups(
+    old_line: str, new_line: str
+) -> list[tuple[int, int, int, int]]:
+    old_tokens = _token_spans(old_line)
+    new_tokens = _token_spans(new_line)
+    old_content_tokens = [token for token in old_tokens if token[0].strip()]
+    new_content_tokens = [token for token in new_tokens if token[0].strip()]
+    if len(old_content_tokens) <= 1 and len(new_content_tokens) <= 1:
+        return []
+
+    matcher = difflib.SequenceMatcher(
+        None,
+        [token for token, _, _ in old_tokens],
+        [token for token, _, _ in new_tokens],
+    )
+    groups = []
+    for tag, old_start, old_end, new_start, new_end in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+
+        old_char_start = _token_boundary(old_tokens, old_start, old_line)
+        old_char_end = _token_boundary(old_tokens, old_end, old_line)
+        new_char_start = _token_boundary(new_tokens, new_start, new_line)
+        new_char_end = _token_boundary(new_tokens, new_end, new_line)
+        groups.append((old_char_start, old_char_end, new_char_start, new_char_end))
+    return groups
+
+
+def _token_boundary(tokens: list[tuple[str, int, int]], index: int, text: str) -> int:
+    if not tokens:
+        return 0
+    if index <= 0:
+        return tokens[0][1]
+    if index >= len(tokens):
+        return len(text)
+    return tokens[index][1]
+
+
+def _context_change_groups(
+    opcodes: list[tuple[str, int, int, int, int]]
+) -> list[tuple[int, int, int, int]]:
+    groups = []
+    current = None
+    for tag, old_start, old_end, new_start, new_end in opcodes:
+        if tag == "equal":
+            if (
+                current is not None
+                and old_end - old_start <= CONTEXT_DIFF_GROUP_EQUAL_LIMIT
+                and new_end - new_start <= CONTEXT_DIFF_GROUP_EQUAL_LIMIT
+            ):
+                current[1] = old_end
+                current[3] = new_end
+            else:
+                if current is not None:
+                    groups.append(tuple(current))
+                    current = None
+            continue
+
+        if current is None:
+            current = [old_start, old_end, new_start, new_end]
+        else:
+            current[1] = old_end
+            current[3] = new_end
+
+    if current is not None:
+        groups.append(tuple(current))
+    return groups
 
 
 def _highlight_line_pair(

--- a/services/notification/telegram.py
+++ b/services/notification/telegram.py
@@ -17,7 +17,10 @@ from models.notice import Notice
 from services.file.attachment_downloader import AttachmentDownloader
 from services.notification.base import BaseNotifier, NotificationChannel
 from services.notification.diff_chunker import split_diff
-from services.notification.formatters import create_telegram_message
+from services.notification.formatters import (
+    create_telegram_message,
+    format_telegram_revised_body_quote,
+)
 from services.file.image import ImageHandler
 
 from services.notification.dev_notifier import DevNotifier
@@ -751,6 +754,8 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
 
                 if diff_text:
                     chunks = split_diff(diff_text, _TELEGRAM_DIFF_CHUNK_LIMIT)
+                    revised_body_quote = format_telegram_revised_body_quote(new_content)
+                    revised_quote_sent = False
                     for idx, chunk in enumerate(chunks):
                         header = (
                             "🔍 <b>상세 변경 내용</b>"
@@ -758,6 +763,13 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                             else f"🔍 <b>상세 변경 내용 ({idx + 1}/{len(chunks)})</b>"
                         )
                         detail_msg = f"{header}\n{chunk}"
+                        if (
+                            revised_body_quote
+                            and idx == len(chunks) - 1
+                            and len(detail_msg) + len(revised_body_quote) + 2
+                            <= constants.TELEGRAM_MAX_MESSAGE_LENGTH
+                        ):
+                            detail_msg += f"\n\n{revised_body_quote}"
                         reply_payload = {
                             "chat_id": self.chat_id,
                             "text": detail_msg,
@@ -771,6 +783,8 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                             session, "sendMessage", payload=reply_payload
                         )
                         if result:
+                            if revised_body_quote and idx == len(chunks) - 1:
+                                revised_quote_sent = revised_body_quote in detail_msg
                             if idx < len(chunks) - 1:
                                 await asyncio.sleep(0.2)
                         elif len(chunks) == 1:
@@ -782,6 +796,19 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                             await self._send_telegram_api(
                                 session, "sendMessage", payload=reply_payload
                             )
+
+                    if revised_body_quote and not revised_quote_sent:
+                        quote_payload = {
+                            "chat_id": self.chat_id,
+                            "text": revised_body_quote,
+                            "reply_to_message_id": main_msg_id,
+                            "parse_mode": "HTML",
+                        }
+                        if topic_id:
+                            quote_payload["message_thread_id"] = topic_id
+                        await self._send_telegram_api(
+                            session, "sendMessage", payload=quote_payload
+                        )
 
                 else:
                     # Diff generation failed but content changed

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -221,3 +221,52 @@ class TestFormatters:
 
         assert "- 첫 번째 요약" in embed["description"]
         assert "- 두 번째 요약" in embed["description"]
+
+    def test_format_revised_body_quote_strips_html_and_breaks_sentences(self):
+        raw = (
+            "<p>첫 번째 문장입니다. "
+            "두 번째 문장입니다. "
+            "세 번째 문장입니다. "
+            "네 번째 문장입니다. "
+            "다섯 번째 문장입니다. "
+            "여섯 번째 문장입니다. "
+            "일곱 번째 문장입니다. "
+            "여덟 번째 문장입니다. "
+            "아홉 번째 문장입니다. "
+            "열 번째 문장입니다. "
+            "열한 번째 문장입니다. "
+            "열두 번째 문장입니다.</p>"
+            "<img src='x.jpg'><script>alert(1)</script>"
+        )
+
+        quote = formatters.format_revised_body_quote(raw)
+
+        assert "첫 번째 문장입니다." in quote
+        assert "두 번째 문장입니다." in quote
+        assert "\n" in quote
+        assert "img" not in quote
+        assert "alert" not in quote
+        assert len(quote) <= 500
+
+    def test_format_revised_body_quote_wraps_long_text_without_sentences(self):
+        raw = "가" * 220
+
+        quote = formatters.format_revised_body_quote(raw)
+
+        assert "\n" in quote
+        assert len(quote) <= 500
+
+    def test_telegram_revised_body_quote_uses_blockquote(self):
+        block = formatters.format_telegram_revised_body_quote("<p>수정 후 <b>본문</b></p>")
+
+        assert "📝 <b>수정 후 원문</b>" in block
+        assert "<blockquote>수정 후 본문</blockquote>" in block
+
+    def test_create_revised_body_quote_field(self):
+        field = formatters.create_revised_body_quote_field("<p>수정 후 본문</p>")
+
+        assert field == {
+            "name": "📝 수정 후 원문",
+            "value": "수정 후 본문",
+            "inline": False,
+        }

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -37,29 +37,43 @@ class TestFormatters:
         assert len(diff) > 1550
         assert "(생략)" not in diff
 
-    def test_generate_clean_diff_telegram_inline_highlight(self):
-        """Test inline HTML highlight for long similar changed lines"""
+    def test_generate_clean_diff_telegram_context_snippet(self):
+        """Test context snippets for long similar changed lines"""
         old = "오늘 오후에는 야외에 제초제 살포 작업을 진행합니다. 안전에 유의해주세요."
         new = "오늘 오후에는 야외에 수목에 방제 작업을 진행합니다. 안전에 유의해주세요."
 
         diff = formatters.generate_clean_diff(old, new, inline_style="telegram")
 
-        assert "🔴" in diff and "🟢" in diff
-        assert "<u>" in diff and "</u>" in diff
+        assert "🔴" not in diff and "🟢" not in diff
+        assert "<u>" not in diff and "</u>" not in diff
+        assert "[" in diff and " → " in diff and "]" in diff
         assert "제초제" in diff
         assert "수목" in diff
 
-    def test_generate_clean_diff_discord_inline_highlight(self):
-        """Test inline Markdown highlight for long similar changed lines"""
+    def test_generate_clean_diff_discord_context_snippet(self):
+        """Test context snippets for long similar changed lines"""
         old = "오늘 오후에는 야외에 제초제 살포 작업을 진행합니다. 안전에 유의해주세요."
         new = "오늘 오후에는 야외에 수목에 방제 작업을 진행합니다. 안전에 유의해주세요."
 
         diff = formatters.generate_clean_diff(old, new, inline_style="discord")
 
-        assert "🔴" in diff and "🟢" in diff
-        assert "**" in diff
+        assert "🔴" not in diff and "🟢" not in diff
+        assert "**" not in diff
+        assert "[" in diff and " → " in diff and "]" in diff
         assert "제초제" in diff
         assert "수목" in diff
+
+    def test_generate_clean_diff_context_multiple_changes(self):
+        """Multiple long-line changes should be shown one snippet per change."""
+        old = "접수 현황 : 25 / 30 온라인 접수 중이며 신청 마감일은 2026.05.10. 입니다."
+        new = "접수 현황 : 26 / 30 온라인 접수 중이며 신청 마감일은 2026.05.11. 입니다."
+
+        diff = formatters.generate_clean_diff(old, new, inline_style="discord")
+
+        lines = diff.splitlines()
+        assert len(lines) == 2
+        assert any("[25 → 26]" in line for line in lines)
+        assert any("[2026.05.10. → 2026.05.11.]" in line for line in lines)
 
     def test_generate_clean_diff_short_lines_stay_line_level(self):
         """Short replacements should stay as plain line-level diff"""

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -176,7 +176,22 @@ class TestFormatters:
 
         msg = formatters.create_telegram_message(notice, is_new=True)
 
-        assert "<blockquote>AI 요약 내용</blockquote>" in msg
+        assert "<blockquote>- AI 요약 내용</blockquote>" in msg
+
+    def test_create_telegram_message_does_not_bullet_short_article_quote(self):
+        notice = Notice(
+            site_key="yu_news",
+            article_id="1",
+            title="공지",
+            content="<p>원문 본문</p>",
+            summary="[단신] 원문 그대로",
+            url="https://example.com",
+        )
+
+        msg = formatters.create_telegram_message(notice, is_new=True)
+
+        assert "<blockquote>원문 그대로</blockquote>" in msg
+        assert "<blockquote>- 원문 그대로</blockquote>" not in msg
 
     def test_create_discord_embed_quotes_content_without_summary(self):
         notice = Notice(
@@ -192,3 +207,17 @@ class TestFormatters:
         assert "원문" in embed["description"]
         assert "본문" in embed["description"]
         assert "<img" not in embed["description"]
+
+    def test_create_discord_embed_bullets_summary_lines(self):
+        notice = Notice(
+            site_key="yu_news",
+            article_id="1",
+            title="공지",
+            summary="첫 번째 요약\n두 번째 요약",
+            url="https://example.com",
+        )
+
+        embed = formatters.create_discord_embed(notice, is_new=True)
+
+        assert "- 첫 번째 요약" in embed["description"]
+        assert "- 두 번째 요약" in embed["description"]


### PR DESCRIPTION
## Canvas 알림 포맷 후속 개선

- 긴 텍스트 diff를 컨텍스트 방식으로 변경 ("...앞뒤 30자 [변경전 → 변경후]...")
- AI 요약 줄 앞에 "- " bullet 추가
- 수정 알림에 수정 후 원본 인용 추가 (500자 제한, 문장 단위 줄바꿈)
- PyMuPDF eager import 회피 (lazy load)