### PR TITLE
fix(notify): restore file replies and improve diff readability

### DIFF
--- a/services/notification/discord.py
+++ b/services/notification/discord.py
@@ -26,8 +26,8 @@ from services.notification.formatters import (
 )
 from services.tag_matcher import TagMatcher
 
-# Discord embed field max is 1024; inline bold diff is sent as plain field text.
-_DISCORD_DIFF_CHUNK_LIMIT = constants.DISCORD_MAX_EMBED_LENGTH
+# Discord embed field max is 1024; reserve room for the fenced code block.
+_DISCORD_DIFF_CHUNK_LIMIT = constants.DISCORD_MAX_EMBED_LENGTH - 12
 
 logger = get_logger(__name__)
 
@@ -41,6 +41,12 @@ def _format_byte_size_discord(size_bytes: int) -> str:
     if kb < 1024:
         return f"{kb:.0f}KB"
     return f"{kb / 1024:.1f}MB"
+
+
+def _discord_code_block(text: str) -> str:
+    """Wrap text in a Discord code block without allowing fence injection."""
+    safe_text = text.replace("```", "`\u200b``")
+    return f"```text\n{safe_text}\n```"
 
 
 class DiscordNotifier(BaseNotifier, NotificationChannel):
@@ -488,7 +494,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                         embed["fields"].append(
                             {
                                 "name": name,
-                                "value": chunk,
+                                "value": _discord_code_block(chunk),
                                 "inline": False,
                             }
                         )
@@ -636,7 +642,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                             update_embed["fields"].append(
                                 {
                                     "name": name,
-                                    "value": chunk,
+                                    "value": _discord_code_block(chunk),
                                     "inline": False,
                                 }
                             )

--- a/services/notification/discord.py
+++ b/services/notification/discord.py
@@ -686,10 +686,21 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                             )
                         )
 
+                        update_message_id = None
+                        try:
+                            update_message_id = (await resp.json()).get("id")
+                        except Exception:
+                            update_message_id = None
+                        reply_anchor_id = update_message_id or existing_thread_id
+
                         if pdf_previews and should_send_previews:
                             for group in pdf_previews:
                                 await self._send_discord_pdf_preview_group(
-                                    session, existing_thread_id, group, headers
+                                    session,
+                                    existing_thread_id,
+                                    group,
+                                    headers,
+                                    reply_to_id=reply_anchor_id,
                                 )
 
                         # Send remaining files if any (Attachments)
@@ -700,6 +711,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                 files_for_attachments,
                                 headers,
                                 is_thread=True,
+                                reply_to_id=reply_anchor_id,
                             )
 
                         return existing_thread_id
@@ -808,7 +820,11 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                     if created_thread_id and pdf_previews:
                         for group in pdf_previews:
                             await self._send_discord_pdf_preview_group(
-                                session, created_thread_id, group, headers
+                                session,
+                                created_thread_id,
+                                group,
+                                headers,
+                                reply_to_id=created_message_id,
                             )
 
                     # If we have attachments, send them to the thread (AFTER previews)
@@ -819,6 +835,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                             files_for_attachments,
                             headers,
                             is_thread=True,
+                            reply_to_id=created_message_id,
                         )
 
                     return created_thread_id
@@ -1013,9 +1030,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
             batch = files[batch_idx : batch_idx + 10]
 
             form = MultipartWriter("form-data")
-            payload = {}
-            if reply_to_id and not is_thread:
-                payload["message_reference"] = {"message_id": reply_to_id}
+            payload = self._discord_reply_payload(reply_to_id)
 
             self._add_text_part(form, "payload_json", json.dumps(payload))
 
@@ -1035,7 +1050,12 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                 logger.error(f"[NOTIFIER] Error sending reply attachments: {e}")
 
     async def _send_discord_pdf_preview_group(
-        self, session: aiohttp.ClientSession, thread_id: str, group: dict, headers: dict
+        self,
+        session: aiohttp.ClientSession,
+        thread_id: str,
+        group: dict,
+        headers: dict,
+        reply_to_id: Optional[str] = None,
     ):
         """Send a group of Discord PDF preview images as a single message."""
         try:
@@ -1046,7 +1066,8 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
             caption = f"📑 [미리보기] {original_filename}"
 
             form = MultipartWriter("form-data")
-            self._add_text_part(form, "payload_json", json.dumps({"content": caption}))
+            payload = self._discord_reply_payload(reply_to_id, content=caption)
+            self._add_text_part(form, "payload_json", json.dumps(payload))
 
             # Add all images in the group
             for idx, img in enumerate(group["images"]):
@@ -1063,3 +1084,19 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                     )
         except Exception as e:
             logger.error(f"[NOTIFIER] Error sending Discord PDF preview group: {e}")
+
+    @staticmethod
+    def _discord_reply_payload(
+        reply_to_id: Optional[str],
+        content: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        if content is not None:
+            payload["content"] = content
+        if reply_to_id:
+            payload["message_reference"] = {
+                "message_id": str(reply_to_id),
+                "fail_if_not_exists": False,
+            }
+            payload["allowed_mentions"] = {"replied_user": False}
+        return payload

--- a/services/notification/discord.py
+++ b/services/notification/discord.py
@@ -23,6 +23,7 @@ from services.notification.formatters import (
     create_discord_embed,
     create_revised_body_quote_field,
     format_change_summary,
+    format_summary_lines,
 )
 from services.tag_matcher import TagMatcher
 
@@ -47,6 +48,10 @@ def _discord_code_block(text: str) -> str:
     """Wrap text in a Discord code block without allowing fence injection."""
     safe_text = text.replace("```", "`\u200b``")
     return f"```text\n{safe_text}\n```"
+
+
+def _discord_updated_summary(summary: str) -> str:
+    return format_summary_lines(summary)[:1000]
 
 
 class DiscordNotifier(BaseNotifier, NotificationChannel):
@@ -616,7 +621,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                 update_embed["fields"].append(
                     {
                         "name": "📝 요약 (업데이트)",
-                        "value": notice.summary[:1000],
+                        "value": _discord_updated_summary(notice.summary),
                         "inline": False,
                     }
                 )

--- a/services/notification/discord.py
+++ b/services/notification/discord.py
@@ -21,7 +21,7 @@ from services.notification.base import BaseNotifier, NotificationChannel
 from services.notification.diff_chunker import split_diff
 from services.notification.formatters import (
     create_discord_embed,
-    create_revised_body_quote_field,
+    create_revised_body_quote_fields,
     format_change_summary,
     format_summary_lines,
 )
@@ -503,9 +503,9 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                 "inline": False,
                             }
                         )
-                    revised_field = create_revised_body_quote_field(new_content)
-                    if revised_field:
-                        embed["fields"].append(revised_field)
+                    embed["fields"].extend(
+                        create_revised_body_quote_fields(new_content)
+                    )
 
         # Add attachment links as the last field (before footer)
         if notice.attachments:
@@ -651,12 +651,13 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                     "inline": False,
                                 }
                             )
-                    revised_field = create_revised_body_quote_field(new_content)
-                    if revised_field:
-                        update_embed["fields"].append(revised_field)
+                    update_embed["fields"].extend(
+                        create_revised_body_quote_fields(new_content)
+                    )
 
             # Prepare Payload
-            payload = {"embeds": [update_embed]}
+            update_embeds = self._split_embed(update_embed)
+            payload = {"embeds": [update_embeds[0]]}
 
             has_files_now = bool(embed_image_data)
 
@@ -681,6 +682,21 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                 async with self._discord_request(session, "POST", reply_url, headers=headers, **kwargs) as resp:
                     if resp.status in [200, 201]:
                         logger.info("[NOTIFIER] Discord update reply sent.")
+                        update_message_id = None
+                        try:
+                            update_message_id = (await resp.json()).get("id")
+                        except Exception:
+                            update_message_id = None
+                        reply_anchor_id = update_message_id or existing_thread_id
+
+                        for followup_embed in update_embeds[1:]:
+                            await self._send_discord_reply_embed(
+                                session,
+                                existing_thread_id,
+                                followup_embed,
+                                headers,
+                                reply_to_id=reply_anchor_id,
+                            )
 
                         # Send PDF previews if available AND relevant changes occurred
                         # Condition: New post OR Attachments changed OR Attachment Text changed
@@ -696,13 +712,6 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                                 ]
                             )
                         )
-
-                        update_message_id = None
-                        try:
-                            update_message_id = (await resp.json()).get("id")
-                        except Exception:
-                            update_message_id = None
-                        reply_anchor_id = update_message_id or existing_thread_id
 
                         if pdf_previews and should_send_previews:
                             for group in pdf_previews:
@@ -941,7 +950,9 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
             total += len(field.get("value", ""))
         return total
 
-    def _split_embed(self, embed: Dict, max_chars: int = 5800) -> List[Dict]:
+    def _split_embed(
+        self, embed: Dict, max_chars: int = 5800, max_fields: int = 25
+    ) -> List[Dict]:
         """
         Splits a single large embed into multiple smaller embeds if it exceeds limits.
         Keeps Title/Desc/Author/Footer on the first embed.
@@ -968,7 +979,10 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
         # Fill first embed
         for field in all_fields:
             field_len = len(field.get("name", "")) + len(field.get("value", ""))
-            if current_len + field_len < max_chars:
+            if (
+                current_len + field_len < max_chars
+                and len(first_embed["fields"]) < max_fields
+            ):
                 first_embed["fields"].append(field)
                 current_len += field_len
             else:
@@ -994,7 +1008,7 @@ class DiscordNotifier(BaseNotifier, NotificationChannel):
                 field = remaining_fields[0]
                 field_len = len(field.get("name", "")) + len(field.get("value", ""))
                 
-                if current_len + field_len < max_chars:
+                if current_len + field_len < max_chars and len(batch_fields) < max_fields:
                     batch_fields.append(remaining_fields.pop(0))
                     current_len += field_len
                 else:

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -145,11 +145,9 @@ def _context_diff_lines(
                 [
                     prefix,
                     _format_diff_line(before, inline_style),
-                    "[",
-                    _format_diff_line(old_segment, inline_style),
-                    " → ",
-                    _format_diff_line(new_segment, inline_style),
-                    "]",
+                    _format_context_replacement(
+                        old_segment, new_segment, inline_style
+                    ),
                     _format_diff_line(after, inline_style),
                     suffix,
                 ]
@@ -386,6 +384,16 @@ def _format_diff_line(text: str, inline_style: Optional[str]) -> str:
     if inline_style == "telegram":
         return html.escape(text, quote=False)
     return text
+
+
+def _format_context_replacement(
+    old_segment: str, new_segment: str, inline_style: Optional[str]
+) -> str:
+    old_text = _format_diff_line(old_segment, inline_style)
+    new_text = _format_diff_line(new_segment, inline_style)
+    if inline_style == "telegram":
+        return f"❌<s>{old_text}</s>❌ → ✅<u>{new_text}</u>✅"
+    return f"❌{old_text}❌ → ✅{new_text}✅"
 
 
 def get_category_emoji(category: str) -> str:

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -553,35 +553,46 @@ def format_date(dt_str: str) -> str:
         return dt_str
 
 
-def format_change_summary(changes: Dict[str, Any]) -> str:
+def format_change_summary(changes: Dict[str, Any], style: str = "markdown") -> str:
     """
     Format granular changes into a summary string.
     """
+    def bold(label: str) -> str:
+        if style == "html":
+            return f"<b>{label}</b>"
+        return f"**{label}**"
+
+    def value(text: Any) -> str:
+        text = str(text)
+        if style == "html":
+            return html.escape(text, quote=False)
+        return text
+
     lines = []
     if "title" in changes:
-        lines.append(f"📝 **제목 변경**: {changes['title']}")
+        lines.append(f"📝 {bold('제목 변경')}: {value(changes['title'])}")
     
     # AI Summary for content
     if "content" in changes:
-        lines.append(f"📝 **내용 변경**: {changes['content']}")
+        lines.append(f"📝 {bold('내용 변경')}: {value(changes['content'])}")
         
     # Granular Attachment Changes
     if "attachments_added" in changes:
         for f in changes["attachments_added"]:
-             lines.append(f"➕ **첨부 추가**: {f}")
+             lines.append(f"➕ {bold('첨부 추가')}: {value(f)}")
     if "attachments_removed" in changes:
         for f in changes["attachments_removed"]:
-             lines.append(f"➖ **첨부 삭제**: {f}")
+             lines.append(f"➖ {bold('첨부 삭제')}: {value(f)}")
              
     # Fallback for generic attachment change
     if "attachments" in changes and not ("attachments_added" in changes or "attachments_removed" in changes):
-        lines.append(f"📎 **첨부파일 변경**: {changes['attachments']}")
+        lines.append(f"📎 {bold('첨부파일 변경')}: {value(changes['attachments'])}")
 
     if "image" in changes:
-        lines.append("🖼️ **이미지 변경됨**")
+        lines.append(f"🖼️ {bold('이미지 변경됨')}")
         
     if "attachment_text" in changes:
-        lines.append(f"📎 **첨부파일 내용 변경**: (상세 내용 확인 필요)")
+        lines.append(f"📎 {bold('첨부파일 내용 변경')}: (상세 내용 확인 필요)")
         
     return "\n".join(lines)
 
@@ -728,7 +739,7 @@ def create_telegram_message(notice, is_new: bool, modified_reason: str = "", cha
 
     # [NEW] Change Summary Header
     if not is_new and changes:
-        change_summary = format_change_summary(changes)
+        change_summary = format_change_summary(changes, style="html")
         if change_summary:
             msg += f"<b>[변경 요약]</b>\n{change_summary}\n\n"
     elif not is_new and modified_reason:

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -506,7 +506,7 @@ def format_telegram_revised_body_quote(raw_text: str) -> str:
     if not quote:
         return ""
     escaped = html.escape(quote, quote=False)
-    return f"📝 <b>수정 후 원문</b>\n<blockquote>{escaped}</blockquote>"
+    return f"📝 <b>수정 후 원문</b>\n<pre>{escaped}</pre>"
 
 
 def create_revised_body_quote_field(raw_text: str) -> Optional[Dict[str, Any]]:

--- a/services/notification/formatters.py
+++ b/services/notification/formatters.py
@@ -499,29 +499,98 @@ def get_notice_quote_text(
 
 
 def format_revised_body_quote(
-    raw_text: str, max_length: int = REVISED_BODY_QUOTE_LENGTH
+    raw_text: str, max_length: Optional[int] = None
 ) -> str:
     """Format the revised body for compact modified-notice detail replies."""
     text = strip_html_text(raw_text)
     if not text:
         return ""
     text = _break_long_text_by_sentence(text)
-    return truncate_text(text, max_length)
+    if max_length:
+        return truncate_text(text, max_length)
+    return text
+
+
+def split_text_chunks(text: str, max_length: int) -> list[str]:
+    """Split text for chat platform limits while preserving line boundaries."""
+    if not text:
+        return []
+    if max_length <= 0:
+        raise ValueError("max_length must be positive")
+    if len(text) <= max_length:
+        return [text]
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for line in text.splitlines(keepends=True):
+        if len(line) > max_length:
+            if current:
+                chunks.append("".join(current).rstrip())
+                current = []
+                current_len = 0
+            for idx in range(0, len(line), max_length):
+                chunks.append(line[idx : idx + max_length].rstrip())
+            continue
+
+        if current_len + len(line) > max_length:
+            chunks.append("".join(current).rstrip())
+            current = [line]
+            current_len = len(line)
+        else:
+            current.append(line)
+            current_len += len(line)
+
+    if current:
+        chunks.append("".join(current).rstrip())
+    return [chunk for chunk in chunks if chunk]
+
+
+def format_telegram_revised_body_quote_parts(
+    raw_text: str,
+    max_length: int = constants.TELEGRAM_MAX_MESSAGE_LENGTH,
+) -> list[str]:
+    quote = format_revised_body_quote(raw_text)
+    if not quote:
+        return []
+
+    # Leave room for the title and <pre> wrapper.
+    body_limit = max_length - 96
+    chunks = split_text_chunks(quote, body_limit)
+    total = len(chunks)
+    parts = []
+    for idx, chunk in enumerate(chunks):
+        title = "수정 후 원문" if total == 1 else f"수정 후 원문 ({idx + 1}/{total})"
+        escaped = html.escape(chunk, quote=False)
+        parts.append(f"📝 <b>{title}</b>\n<pre>{escaped}</pre>")
+    return parts
 
 
 def format_telegram_revised_body_quote(raw_text: str) -> str:
-    quote = format_revised_body_quote(raw_text)
-    if not quote:
-        return ""
-    escaped = html.escape(quote, quote=False)
-    return f"📝 <b>수정 후 원문</b>\n<pre>{escaped}</pre>"
+    return "\n\n".join(format_telegram_revised_body_quote_parts(raw_text))
 
 
 def create_revised_body_quote_field(raw_text: str) -> Optional[Dict[str, Any]]:
+    fields = create_revised_body_quote_fields(raw_text)
+    return fields[0] if fields else None
+
+
+def create_revised_body_quote_fields(
+    raw_text: str,
+    max_length: int = 1000,
+) -> list[Dict[str, Any]]:
     quote = format_revised_body_quote(raw_text)
     if not quote:
-        return None
-    return {"name": "📝 수정 후 원문", "value": quote, "inline": False}
+        return []
+
+    chunks = split_text_chunks(quote, max_length)
+    total = len(chunks)
+    fields = []
+    for idx, chunk in enumerate(chunks):
+        name = "📝 수정 후 원문" if total == 1 else f"📝 수정 후 원문 ({idx + 1}/{total})"
+        fields.append({"name": name, "value": chunk, "inline": False})
+    return fields
 
 
 def _break_long_text_by_sentence(text: str) -> str:

--- a/services/notification/telegram.py
+++ b/services/notification/telegram.py
@@ -709,7 +709,7 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                                     # Small delay between chunks to prevent rate limiting (even with retries)
                                     await asyncio.sleep(1.0)
 
-        # 2.2 Send Attachments as MediaGroup (All Together)
+        # 2.2 Send original attachments as replies after previews
         if main_msg_id and notice.attachments:
             collected_files = await self.downloader.download_attachments(
                 session,
@@ -718,29 +718,14 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                 referer=notice.url,
             )
 
-            # Send all files as MediaGroup
-            if collected_files:
-                media = []
-                form = MultipartWriter("form-data")
-
-                for idx, (filename, filedata) in enumerate(collected_files):
-                    field_name = f"doc{idx}"
-                    self._add_file_part(form, field_name, filedata, filename)
-                    media.append(
-                        {"type": "document", "media": f"attach://{field_name}"}
-                    )
-
-                self._add_text_part(form, "media", json.dumps(media))
-                self._add_text_part(form, "chat_id", str(self.chat_id))
-                if topic_id:
-                    self._add_text_part(form, "message_thread_id", str(topic_id))
-                self._add_text_part(form, "reply_to_message_id", str(main_msg_id))
-
-                result = await self._send_telegram_api(session, "sendMediaGroup", data=form)
-                if result:
-                    logger.info(
-                        f"[NOTIFIER] Sent {len(collected_files)} files as MediaGroup"
-                    )
+            for filename, filedata in collected_files:
+                await self._send_original_document_reply(
+                    session=session,
+                    filename=filename,
+                    filedata=filedata,
+                    topic_id=topic_id,
+                    reply_to_message_id=main_msg_id,
+                )
 
         # 2.3 Send Detailed Change Content (if modified)
         if main_msg_id and modified_reason and notice.change_details:
@@ -829,6 +814,31 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                     )
 
         return main_msg_id
+
+    async def _send_original_document_reply(
+        self,
+        session: aiohttp.ClientSession,
+        filename: str,
+        filedata: bytes,
+        topic_id: Optional[int],
+        reply_to_message_id: int,
+    ) -> None:
+        """Send one original attachment as a document reply."""
+        form = MultipartWriter("form-data")
+        self._add_text_part(form, "chat_id", str(self.chat_id))
+        self._add_text_part(form, "reply_to_message_id", str(reply_to_message_id))
+        if topic_id:
+            self._add_text_part(form, "message_thread_id", str(topic_id))
+        self._add_text_part(
+            form,
+            "caption",
+            self._original_caption(filename, len(filedata)),
+        )
+        self._add_file_part(form, "document", filedata, filename)
+
+        result = await self._send_telegram_api(session, "sendDocument", data=form)
+        if result:
+            logger.info(f"[NOTIFIER] Sent original attachment reply: {filename}")
 
     async def send_menu_notification(
         self, session: aiohttp.ClientSession, notice: Notice, menu_data: Dict[str, Any]

--- a/services/notification/telegram.py
+++ b/services/notification/telegram.py
@@ -19,7 +19,7 @@ from services.notification.base import BaseNotifier, NotificationChannel
 from services.notification.diff_chunker import split_diff
 from services.notification.formatters import (
     create_telegram_message,
-    format_telegram_revised_body_quote,
+    format_telegram_revised_body_quote_parts,
 )
 from services.file.image import ImageHandler
 
@@ -739,7 +739,9 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
 
                 if diff_text:
                     chunks = split_diff(diff_text, _TELEGRAM_DIFF_CHUNK_LIMIT)
-                    revised_body_quote = format_telegram_revised_body_quote(new_content)
+                    revised_body_parts = format_telegram_revised_body_quote_parts(
+                        new_content
+                    )
                     revised_quote_sent = False
                     for idx, chunk in enumerate(chunks):
                         header = (
@@ -749,12 +751,12 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                         )
                         detail_msg = f"{header}\n<blockquote>{chunk}</blockquote>"
                         if (
-                            revised_body_quote
+                            len(revised_body_parts) == 1
                             and idx == len(chunks) - 1
-                            and len(detail_msg) + len(revised_body_quote) + 2
+                            and len(detail_msg) + len(revised_body_parts[0]) + 2
                             <= constants.TELEGRAM_MAX_MESSAGE_LENGTH
                         ):
-                            detail_msg += f"\n\n{revised_body_quote}"
+                            detail_msg += f"\n\n{revised_body_parts[0]}"
                         reply_payload = {
                             "chat_id": self.chat_id,
                             "text": detail_msg,
@@ -768,8 +770,8 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                             session, "sendMessage", payload=reply_payload
                         )
                         if result:
-                            if revised_body_quote and idx == len(chunks) - 1:
-                                revised_quote_sent = revised_body_quote in detail_msg
+                            if revised_body_parts and idx == len(chunks) - 1:
+                                revised_quote_sent = revised_body_parts[0] in detail_msg
                             if idx < len(chunks) - 1:
                                 await asyncio.sleep(0.2)
                         elif len(chunks) == 1:
@@ -782,18 +784,20 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                                 session, "sendMessage", payload=reply_payload
                             )
 
-                    if revised_body_quote and not revised_quote_sent:
-                        quote_payload = {
-                            "chat_id": self.chat_id,
-                            "text": revised_body_quote,
-                            "reply_to_message_id": main_msg_id,
-                            "parse_mode": "HTML",
-                        }
-                        if topic_id:
-                            quote_payload["message_thread_id"] = topic_id
-                        await self._send_telegram_api(
-                            session, "sendMessage", payload=quote_payload
-                        )
+                    if revised_body_parts and not revised_quote_sent:
+                        for part in revised_body_parts:
+                            quote_payload = {
+                                "chat_id": self.chat_id,
+                                "text": part,
+                                "reply_to_message_id": main_msg_id,
+                                "parse_mode": "HTML",
+                            }
+                            if topic_id:
+                                quote_payload["message_thread_id"] = topic_id
+                            await self._send_telegram_api(
+                                session, "sendMessage", payload=quote_payload
+                            )
+                            await asyncio.sleep(0.2)
 
                 else:
                     # Diff generation failed but content changed

--- a/services/notification/telegram.py
+++ b/services/notification/telegram.py
@@ -25,8 +25,8 @@ from services.file.image import ImageHandler
 
 from services.notification.dev_notifier import DevNotifier
 
-# Telegram messages cap at 4096; reserve room for the header/code wrapper.
-_TELEGRAM_DIFF_CHUNK_LIMIT = constants.TELEGRAM_MAX_MESSAGE_LENGTH - 96
+# Telegram messages cap at 4096; reserve room for the header/block quote wrapper.
+_TELEGRAM_DIFF_CHUNK_LIMIT = constants.TELEGRAM_MAX_MESSAGE_LENGTH - 128
 
 logger = get_logger(__name__)
 
@@ -747,7 +747,7 @@ class TelegramNotifier(BaseNotifier, NotificationChannel):
                             if len(chunks) == 1
                             else f"🔍 <b>상세 변경 내용 ({idx + 1}/{len(chunks)})</b>"
                         )
-                        detail_msg = f"{header}\n{chunk}"
+                        detail_msg = f"{header}\n<blockquote>{chunk}</blockquote>"
                         if (
                             revised_body_quote
                             and idx == len(chunks) - 1

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -265,7 +265,6 @@ class TestFormatters:
         assert "\n" in quote
         assert "img" not in quote
         assert "alert" not in quote
-        assert len(quote) <= 500
 
     def test_format_revised_body_quote_wraps_long_text_without_sentences(self):
         raw = "가" * 220
@@ -273,7 +272,13 @@ class TestFormatters:
         quote = formatters.format_revised_body_quote(raw)
 
         assert "\n" in quote
-        assert len(quote) <= 500
+
+    def test_format_revised_body_quote_does_not_truncate_by_default(self):
+        raw = "가" * 700
+
+        quote = formatters.format_revised_body_quote(raw)
+
+        assert len(quote.replace("\n", "")) == 700
 
     def test_telegram_revised_body_quote_uses_pre(self):
         block = formatters.format_telegram_revised_body_quote("<p>수정 후 <b>본문</b></p>")
@@ -289,3 +294,20 @@ class TestFormatters:
             "value": "수정 후 본문",
             "inline": False,
         }
+
+    def test_create_revised_body_quote_fields_splits_long_body(self):
+        fields = formatters.create_revised_body_quote_fields("가" * 250, max_length=80)
+
+        assert len(fields) > 1
+        assert fields[0]["name"].startswith("📝 수정 후 원문 (1/")
+        assert all(len(field["value"]) <= 80 for field in fields)
+
+    def test_telegram_revised_body_quote_parts_split_long_body(self):
+        parts = formatters.format_telegram_revised_body_quote_parts(
+            "가" * 250, max_length=180
+        )
+
+        assert len(parts) > 1
+        assert parts[0].startswith("📝 <b>수정 후 원문 (1/")
+        assert all(len(part) <= 180 for part in parts)
+        assert "<pre>" in parts[0]

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -45,8 +45,8 @@ class TestFormatters:
         diff = formatters.generate_clean_diff(old, new, inline_style="telegram")
 
         assert "🔴" not in diff and "🟢" not in diff
-        assert "<u>" not in diff and "</u>" not in diff
-        assert "[" in diff and " → " in diff and "]" in diff
+        assert "❌<s>" in diff and "</s>❌ → ✅<u>" in diff and "</u>✅" in diff
+        assert "[" not in diff and "]" not in diff
         assert "제초제" in diff
         assert "수목" in diff
 
@@ -59,7 +59,8 @@ class TestFormatters:
 
         assert "🔴" not in diff and "🟢" not in diff
         assert "**" not in diff
-        assert "[" in diff and " → " in diff and "]" in diff
+        assert "❌" in diff and " → " in diff and "✅" in diff
+        assert "[" not in diff and "]" not in diff
         assert "제초제" in diff
         assert "수목" in diff
 
@@ -72,8 +73,8 @@ class TestFormatters:
 
         lines = diff.splitlines()
         assert len(lines) == 2
-        assert any("[25 → 26]" in line for line in lines)
-        assert any("[2026.05.10. → 2026.05.11.]" in line for line in lines)
+        assert any("❌25❌ → ✅26✅" in line for line in lines)
+        assert any("❌2026.05.10.❌ → ✅2026.05.11.✅" in line for line in lines)
 
     def test_generate_clean_diff_long_single_line_one_digit_change_uses_context(self):
         """Long one-line notices should not fall back to full red/green blocks."""
@@ -89,7 +90,7 @@ class TestFormatters:
         diff = formatters.generate_clean_diff(old, new, inline_style="telegram")
 
         assert "🔴" not in diff and "🟢" not in diff
-        assert "[4 → 5]" in diff
+        assert "❌<s>4</s>❌ → ✅<u>5</u>✅" in diff
         assert "접수 현황" in diff
         assert "/ 40 온라인" in diff
 

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -274,11 +274,11 @@ class TestFormatters:
         assert "\n" in quote
         assert len(quote) <= 500
 
-    def test_telegram_revised_body_quote_uses_blockquote(self):
+    def test_telegram_revised_body_quote_uses_pre(self):
         block = formatters.format_telegram_revised_body_quote("<p>수정 후 <b>본문</b></p>")
 
         assert "📝 <b>수정 후 원문</b>" in block
-        assert "<blockquote>수정 후 본문</blockquote>" in block
+        assert "<pre>수정 후 본문</pre>" in block
 
     def test_create_revised_body_quote_field(self):
         field = formatters.create_revised_body_quote_field("<p>수정 후 본문</p>")

--- a/tests/unit/test_formatters_extended.py
+++ b/tests/unit/test_formatters_extended.py
@@ -36,3 +36,15 @@ class TestFormattersExtended:
         assert "➕ **첨부 추가**: file1.hwp" in result
         assert "➖ **첨부 삭제**: file2.pdf" in result
         assert "📎 **첨부파일 내용 변경**" in result
+
+    def test_format_change_summary_html_bold_for_telegram(self):
+        changes = {
+            "content": "변경 요약",
+            "attachments_added": ["자료<1>.pdf"],
+        }
+
+        result = format_change_summary(changes, style="html")
+
+        assert "📝 <b>내용 변경</b>: 변경 요약" in result
+        assert "➕ <b>첨부 추가</b>: 자료&lt;1&gt;.pdf" in result
+        assert "**내용 변경**" not in result

--- a/tests/unit/test_notification_attachment_replies.py
+++ b/tests/unit/test_notification_attachment_replies.py
@@ -1,0 +1,32 @@
+import urllib.parse
+
+from aiohttp import MultipartWriter
+
+from services.notification.base import BaseNotifier
+from services.notification.discord import DiscordNotifier
+
+
+def test_file_part_includes_utf8_filename_star_for_korean_names():
+    writer = MultipartWriter("form-data")
+    filename = "강의자료 원본.pdf"
+
+    BaseNotifier()._add_file_part(writer, "files[0]", b"data", filename)
+
+    part = writer._parts[0][0]
+    disposition = part.headers["Content-Disposition"]
+
+    assert f'filename="{filename}"' in disposition
+    assert f"filename*=UTF-8''{urllib.parse.quote(filename)}" in disposition
+
+
+def test_discord_reply_payload_references_original_message():
+    payload = DiscordNotifier._discord_reply_payload(
+        "1234567890", content="📎 [원본] 강의자료.pdf (10KB)"
+    )
+
+    assert payload["content"].startswith("📎 [원본]")
+    assert payload["message_reference"] == {
+        "message_id": "1234567890",
+        "fail_if_not_exists": False,
+    }
+    assert payload["allowed_mentions"] == {"replied_user": False}

--- a/tests/unit/test_notification_attachment_replies.py
+++ b/tests/unit/test_notification_attachment_replies.py
@@ -3,7 +3,11 @@ import urllib.parse
 from aiohttp import MultipartWriter
 
 from services.notification.base import BaseNotifier
-from services.notification.discord import DiscordNotifier, _discord_code_block
+from services.notification.discord import (
+    DiscordNotifier,
+    _discord_code_block,
+    _discord_updated_summary,
+)
 
 
 def test_file_part_includes_utf8_filename_star_for_korean_names():
@@ -36,3 +40,9 @@ def test_discord_code_block_wraps_modified_details():
     block = _discord_code_block("🔴 이전\n🟢 이후")
 
     assert block == "```text\n🔴 이전\n🟢 이후\n```"
+
+
+def test_discord_updated_summary_adds_bullets():
+    summary = _discord_updated_summary("첫 번째 요약\n- 이미 있는 요약")
+
+    assert summary == "- 첫 번째 요약\n- 이미 있는 요약"

--- a/tests/unit/test_notification_attachment_replies.py
+++ b/tests/unit/test_notification_attachment_replies.py
@@ -3,7 +3,7 @@ import urllib.parse
 from aiohttp import MultipartWriter
 
 from services.notification.base import BaseNotifier
-from services.notification.discord import DiscordNotifier
+from services.notification.discord import DiscordNotifier, _discord_code_block
 
 
 def test_file_part_includes_utf8_filename_star_for_korean_names():
@@ -30,3 +30,9 @@ def test_discord_reply_payload_references_original_message():
         "fail_if_not_exists": False,
     }
     assert payload["allowed_mentions"] == {"replied_user": False}
+
+
+def test_discord_code_block_wraps_modified_details():
+    block = _discord_code_block("🔴 이전\n🟢 이후")
+
+    assert block == "```text\n🔴 이전\n🟢 이후\n```"


### PR DESCRIPTION
- 미리보기 후 원본 파일 답글 전송 복원 (텔레그램/디스코드)
- 상세 변경 내용 포맷 변경 (텔레그램 인용, 디스코드 코드블록)
- 컨텍스트 diff 구분 기호를 «» 방식으로 변경 (괄호 충돌 방지)
- 텔레그램 변경 요약 볼드체 HTML 렌더링 수정
- 디스코드 수정 알림 요약에 bullet 추가
- 수정 후 원문 전체 표시 (글자수 제한 제거, 길면 분할 전송)